### PR TITLE
Check for has(python) || has(python3)

### DIFF
--- a/plugin/sort_python_imports.vim
+++ b/plugin/sort_python_imports.vim
@@ -21,7 +21,7 @@
 "  1.0 - initial upload
 "
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-if !has('python')
+if !(has('python') || has('python3'))
     s:ErrMsg( "Error: Required vim compiled with +python" )
     finish
 endif


### PR DESCRIPTION
This should fix support for vim compiled with +python3/dyn

I prefer this script to ``g:pymode_rope_organize_imports_bind`` because it doesn't remove imports for typing types that are only present in comments.
https://github.com/python-mode/python-mode/blob/1e97e4d8fa427f7b3262b2daadff8d32ca5be536/doc/pymode.txt#L567